### PR TITLE
chore: add badges, CODEOWNERS, and local dev setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @PetarStoev02

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,32 @@ Use conventional commits:
 - Link to the related issue if there is one
 - Make sure tests pass
 
+## Local development
+
+```bash
+git clone https://github.com/YOUR_USERNAME/cli.git
+cd cli
+npm install
+```
+
+### Run the dev build
+
+```bash
+npm run dev
+```
+
+### Run tests
+
+```bash
+npm test
+```
+
+### Run all CI checks locally
+
+```bash
+npm run typecheck && npm run lint && npm run format:check && npm run build && npm test
+```
+
 ## Related Repos
 
 - [@w3-kit/registry](https://github.com/w3-kit/registry) — Chain/token data

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # w3-kit
 
+[![CI](https://github.com/w3-kit/cli/actions/workflows/ci.yml/badge.svg)](https://github.com/w3-kit/cli/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/w3-kit)](https://www.npmjs.com/package/w3-kit)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+
 CLI toolkit for web3 development.
 
 ## Install


### PR DESCRIPTION
## Summary
- Add CI, npm, and license badges to README.md
- Create `.github/CODEOWNERS` assigning @PetarStoev02 as default reviewer
- Add "Local development" section to CONTRIBUTING.md with dev build, test, and CI check commands